### PR TITLE
Abstract KafkaNet with simple API

### DIFF
--- a/Consumer/Consumer.csproj
+++ b/Consumer/Consumer.csproj
@@ -66,6 +66,12 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleKafka\SimpleKafka.csproj">
+      <Project>{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}</Project>
+      <Name>SimpleKafka</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Consumer/Program.cs
+++ b/Consumer/Program.cs
@@ -1,14 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
-using Kafka.Client.Cfg;
-using Kafka.Client.Consumers;
-using Kafka.Client.Messages;
-using Kafka.Client.Requests;
-using Kafka.Client.Serialization;
-using System.Text;
 using Metrics;
+using SimpleKafka;
 
 namespace Consumer
 {
@@ -19,62 +12,34 @@ namespace Consumer
             var zookeeperString = args.Length > 0 ? args[0] : "192.168.33.10:2181";
             var consumerGroupId = args.Length > 1 ? args[1] : "test.group";
             var testTopic = args.Length > 2 ? args[2] : "test.topic";
-
-            var uniqueConsumerId = consumerGroupId + "." + Guid.NewGuid().ToString("N");
-            var m_BufferMaxNoOfMessages = 1000;
-            var fetchSize = 11 * 1024 * 1024;
-
+            
             var timer = Metric.Timer("Received", Unit.Events);
             Metric.Config.WithReporting(r => r.WithConsoleReport(TimeSpan.FromSeconds(5)));
 
-            // Here we create a balanced consumer on one consumer machine for consumerGroupId. All machines consuming for this group will get balanced together
-            ConsumerConfiguration config = new ConsumerConfiguration
-            {
-                AutoCommit = false,
-                GroupId = consumerGroupId,
-                ConsumerId = uniqueConsumerId,
-                MaxFetchBufferLength = m_BufferMaxNoOfMessages,
-                FetchSize = fetchSize,
-                AutoOffsetReset = OffsetRequest.LargestTime,
-                NumberOfTries = 20,
-                ZooKeeper = new ZooKeeperConfiguration(zookeeperString, 30000, 30000, 2000)
-            };
-            var balancedConsumer = new ZookeeperConsumerConnector(config, true, RebalanceHandler, ZkDisconnectedHandler, ZkExpiredHandler);
-            // grab streams for desired topics 
-            var streams = balancedConsumer.CreateMessageStreams(new ConcurrentDictionary<string, int>(new Dictionary<string, int>
-            {
-                { testTopic, 1 }
-            }), new DefaultDecoder());
-            var stream = streams[testTopic][0];
-            var cancellationTokenSource = new CancellationTokenSource();
+            var handler = new AutoResetEvent(false);
             Console.CancelKeyPress += (sender, eventArgs) =>
             {
-                cancellationTokenSource.Cancel();
-                balancedConsumer.Dispose();
+                eventArgs.Cancel = true;
+                handler.Set();
             };
-            foreach (Message message in stream.GetCancellable(cancellationTokenSource.Token))
+
+            using (var client = new KafkaClient(zookeeperString))
             {
-                var time = DateTime.UtcNow.Ticks;
-                var text = Encoding.UTF8.GetString(message.Payload);
-                var value = long.Parse(text);
-                var diff = (time - value) / 10000;
-                timer.Record(diff, TimeUnit.Milliseconds);
+                var consumerGroup = client.Consumer(consumerGroupId);
+                using (var instance = consumerGroup.Join())
+                {
+                    instance.Subscribe(testTopic)
+                        .Data(message =>
+                        {
+                            var time = DateTime.UtcNow.Ticks;
+                            var value = long.Parse(message.Value);
+                            var diff = (time - value) / 10000;
+                            timer.Record(diff, TimeUnit.Milliseconds);
+                        })
+                        .Start();
+                    handler.WaitOne();
+                }
             }
-        }
-
-        private static void ZkExpiredHandler(object sender, EventArgs eventArgs)
-        {
-            Console.WriteLine($"{DateTime.Now.Ticks}:ZK_EXPIRE");
-        }
-
-        private static void ZkDisconnectedHandler(object sender, EventArgs eventArgs)
-        {
-            Console.WriteLine($"{DateTime.Now.Ticks}:ZK_DISCONNECT");
-        }
-
-        public static void RebalanceHandler(object sender, EventArgs eventArgs)
-        {
-            Console.WriteLine($"{DateTime.Now.Ticks}:REBALANCE");
         }
     }
 }

--- a/KafkaNet.Tests.sln
+++ b/KafkaNet.Tests.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumer", "Consumer\Consum
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Producer", "Producer\Producer.csproj", "{74056D3B-B715-4D64-BC36-0807F1C468E9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleKafka", "SimpleKafka\SimpleKafka.csproj", "{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{74056D3B-B715-4D64-BC36-0807F1C468E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74056D3B-B715-4D64-BC36-0807F1C468E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74056D3B-B715-4D64-BC36-0807F1C468E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Producer/Program.cs
+++ b/Producer/Program.cs
@@ -1,16 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using Kafka.Client.Cfg;
-using Kafka.Client.Messages;
-using Kafka.Client.Producers;
 using Metrics;
 using SimpleKafka;
-using Message = Kafka.Client.Messages.Message;
 
 namespace Producer
 {
@@ -35,7 +27,7 @@ namespace Producer
                 var batch =
                     Enumerable.Range(0, 100)
                         .Select(i =>
-                            new SimpleKafka.Message
+                            new Message
                             {
                                 Key = i.ToString(),
                                 Value = DateTime.UtcNow.Ticks.ToString()

--- a/Producer/Program.cs
+++ b/Producer/Program.cs
@@ -9,6 +9,8 @@ using Kafka.Client.Cfg;
 using Kafka.Client.Messages;
 using Kafka.Client.Producers;
 using Metrics;
+using SimpleKafka;
+using Message = Kafka.Client.Messages.Message;
 
 namespace Producer
 {
@@ -16,23 +18,15 @@ namespace Producer
     {
         static void Main(string[] args)
         {
-            var kafkaServerName = args.Length > 0 ? args[0] : "192.168.33.10";
+            var zkConnect = args.Length > 0 ? args[0] : "192.168.33.10:2181";
             var testTopic = args.Length > 0 ? args[1] : "test.topic";
-
-            var brokerId = 0;
-            var kafkaPort = 9092;
 
             var timer = Metric.Timer("Sent", Unit.Events);
             Metric.Config.WithReporting(r => r.WithConsoleReport(TimeSpan.FromSeconds(5)));
 
-            var brokerConfig = new BrokerConfiguration()
-            {
-                BrokerId = brokerId,
-                Host = kafkaServerName,
-                Port = kafkaPort
-            };
-            var config = new ProducerConfiguration(new List<BrokerConfiguration> { brokerConfig });
-            var kafkaProducer = new Kafka.Client.Producers.Producer(config);
+            var client = new KafkaClient(zkConnect);
+            var topic = client.Topic(testTopic);
+
             var stop = false;
             Console.CancelKeyPress += (sender, eventArgs) => stop = true;
             while (!stop)
@@ -41,17 +35,14 @@ namespace Producer
                 var batch =
                     Enumerable.Range(0, 100)
                         .Select(i =>
-                            new ProducerData<string, Message>(testTopic, new[]
+                            new SimpleKafka.Message
                             {
-                                new Message(
-                                    Encoding.UTF8.GetBytes(DateTime.UtcNow.Ticks.ToString()),
-                                    Encoding.UTF8.GetBytes(i.ToString()),
-                                    CompressionCodecs.NoCompressionCodec
-                                    )
+                                Key = i.ToString(),
+                                Value = DateTime.UtcNow.Ticks.ToString()
                             })
-                        );
+                        .ToArray();
                 var time = DateTime.UtcNow.Ticks;
-                kafkaProducer.Send(batch);
+                topic.Send(batch);
                 var diff = (DateTime.UtcNow.Ticks - time) / 10000;
                 timer.Record(diff, TimeUnit.Milliseconds);
             }

--- a/SimpleKafka/KafkaClient.cs
+++ b/SimpleKafka/KafkaClient.cs
@@ -7,14 +7,18 @@ namespace SimpleKafka
     public interface IKafkaClient : IDisposable
     {
         IKafkaTopic Topic(string name);
+        IKafkaConsumer Consumer(string groupName);
+        void Dispose();
     }
 
     public class KafkaClient : IKafkaClient
     {
+        private readonly string _zkConnect;
         private readonly ZooKeeperClient _zkClient;
 
         public KafkaClient(string zkConnect)
         {
+            _zkConnect = zkConnect;
             var kafkaConfig = new KafkaSimpleManagerConfiguration()
             {
                 Zookeeper = zkConnect,
@@ -22,7 +26,7 @@ namespace SimpleKafka
                 PartitionerClass = ProducerConfiguration.DefaultPartitioner
             };
             kafkaConfig.Verify();
-
+            
             _zkClient = new ZooKeeperClient(
                 zkConnect,
                 ZooKeeperConfiguration.DefaultSessionTimeout,
@@ -34,6 +38,11 @@ namespace SimpleKafka
         public IKafkaTopic Topic(string name)
         {
             return new KafkaTopic(_zkClient, name);
+        }
+
+        public IKafkaConsumer Consumer(string groupName)
+        {
+            return new KafkaConsumer(_zkConnect, groupName);
         }
 
         public void Dispose()

--- a/SimpleKafka/KafkaClient.cs
+++ b/SimpleKafka/KafkaClient.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Kafka.Client.Cfg;
+using Kafka.Client.ZooKeeperIntegration;
+
+namespace SimpleKafka
+{
+    public interface IKafkaClient : IDisposable
+    {
+        IKafkaTopic Topic(string name);
+    }
+
+    public class KafkaClient : IKafkaClient
+    {
+        private readonly ZooKeeperClient _zkClient;
+
+        public KafkaClient(string zkConnect)
+        {
+            var kafkaConfig = new KafkaSimpleManagerConfiguration()
+            {
+                Zookeeper = zkConnect,
+                MaxMessageSize = SyncProducerConfiguration.DefaultMaxMessageSize,
+                PartitionerClass = ProducerConfiguration.DefaultPartitioner
+            };
+            kafkaConfig.Verify();
+
+            _zkClient = new ZooKeeperClient(
+                zkConnect,
+                ZooKeeperConfiguration.DefaultSessionTimeout,
+                ZooKeeperStringSerializer.Serializer
+                );
+            _zkClient.Connect();
+        }
+
+        public IKafkaTopic Topic(string name)
+        {
+            return new KafkaTopic(_zkClient, name);
+        }
+
+        public void Dispose()
+        {
+            _zkClient.Dispose();
+        }
+    }
+}

--- a/SimpleKafka/KafkaConsumer.cs
+++ b/SimpleKafka/KafkaConsumer.cs
@@ -1,0 +1,24 @@
+﻿namespace SimpleKafka
+{
+    public interface IKafkaConsumer
+    {
+        KafkaConsumerInstance Join();
+    }
+
+    public class KafkaConsumer : IKafkaConsumer
+    {
+        private readonly string _zkConnect;
+        private readonly string _groupName;
+
+        public KafkaConsumer(string zkConnect, string groupName)
+        {
+            _zkConnect = zkConnect;
+            _groupName = groupName;
+        }
+
+        public KafkaConsumerInstance Join()
+        {
+            return new KafkaConsumerInstance(_zkConnect, _groupName);
+        }
+    }
+}

--- a/SimpleKafka/KafkaConsumerInstance.cs
+++ b/SimpleKafka/KafkaConsumerInstance.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Kafka.Client.Cfg;
+using Kafka.Client.Consumers;
+using Kafka.Client.Serialization;
+
+namespace SimpleKafka
+{
+    public interface IKafkaConsumerInstance : IDisposable
+    {
+        KafkaConsumerStream Subscribe(string topicName);
+    }
+
+    public class KafkaConsumerInstance : IKafkaConsumerInstance
+    {
+        private readonly IList<IKafkaConsumerStream> _streams = new List<IKafkaConsumerStream>();
+        private readonly ZookeeperConsumerConnector _balancedConsumer;
+
+        public KafkaConsumerInstance(string zkConnect, string groupName)
+        {
+            var config = new ConsumerConfiguration
+            {
+                AutoCommit = false,
+                GroupId = groupName,
+                ZooKeeper = new ZooKeeperConfiguration(
+                    zkConnect,
+                    ZooKeeperConfiguration.DefaultSessionTimeout,
+                    ZooKeeperConfiguration.DefaultConnectionTimeout,
+                    ZooKeeperConfiguration.DefaultSyncTime
+                    )
+            };
+
+            _balancedConsumer = new ZookeeperConsumerConnector(
+                config,
+                true,
+                OnRebalance,
+                OnZkDisconnect,
+                OnZkExpired
+                );
+        }
+
+        public KafkaConsumerStream Subscribe(string topicName)
+        {
+            var streams = _balancedConsumer.CreateMessageStreams(
+                new Dictionary<string, int>
+                {
+                    {topicName, 1}
+                },
+                new DefaultDecoder()
+                );
+
+            var stream = streams[topicName][0];
+
+            var consumerStream = new KafkaConsumerStream(stream);
+            _streams.Add(consumerStream);
+            return consumerStream;
+        }
+
+        private void OnZkExpired(object sender, EventArgs e)
+        {
+            Console.WriteLine($"{DateTime.Now.ToString("s")}: ZK_EXPIRED");
+        }
+
+        private void OnZkDisconnect(object sender, EventArgs e)
+        {
+            Console.WriteLine($"{DateTime.Now.ToString("s")}: ZK_DISCONNECT");
+        }
+
+        private void OnRebalance(object sender, EventArgs e)
+        {
+            Console.WriteLine($"{DateTime.Now.ToString("s")}: ZK_REBALANCE");
+        }
+
+        public void Shutdown()
+        {
+            foreach (var stream in _streams)
+            {
+                stream.Shutdown();
+            }
+            _streams.Clear();
+            _balancedConsumer.CommitOffsets();
+            _balancedConsumer.ReleaseAllPartitionOwnerships();
+        }
+
+        public void Dispose()
+        {
+            if (_streams.Any())
+            {
+                Shutdown();
+            }
+            _balancedConsumer.Dispose();
+        }
+    }
+}

--- a/SimpleKafka/KafkaConsumerStream.cs
+++ b/SimpleKafka/KafkaConsumerStream.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Text;
+using System.Threading;
+using Kafka.Client.Consumers;
+
+namespace SimpleKafka
+{
+    public interface IKafkaConsumerStream
+    {
+        IKafkaConsumerStream Data(Action<Message> action);
+        IKafkaConsumerStream Error(Action<Exception> action);
+        IKafkaConsumerStream Close(Action action);
+        void Start();
+        void Shutdown();
+    }
+
+    public class KafkaConsumerStream : IKafkaConsumerStream
+    {
+        private readonly KafkaMessageStream<Kafka.Client.Messages.Message> _stream;
+        private readonly CancellationTokenSource _tokenSource;
+        private readonly Thread _thread;
+        private bool _running;
+        private Action<Message> _dataSubscriber;
+        private Action<Exception> _errorSubscriber;
+        private Action _closeSubscriber;
+
+        public KafkaConsumerStream(KafkaMessageStream<Kafka.Client.Messages.Message> stream)
+        {
+            _tokenSource = new CancellationTokenSource();
+            _stream = (KafkaMessageStream<Kafka.Client.Messages.Message>)stream.GetCancellable(_tokenSource.Token);
+            _thread = new Thread(RunConsumer);
+        }
+
+        public IKafkaConsumerStream Data(Action<Message> action)
+        {
+            _dataSubscriber = action;
+            return this;
+        }
+
+        public IKafkaConsumerStream Error(Action<Exception> action)
+        {
+            _errorSubscriber = action;
+            return this;
+        }
+
+        public IKafkaConsumerStream Close(Action action)
+        {
+            _closeSubscriber = action;
+            return this;
+        }
+
+        public void Start()
+        {
+            _running = true;
+            _thread.Start();
+        }
+
+        private void RunConsumer()
+        {
+            while (_running)
+            {
+                if (_dataSubscriber == null) continue;
+
+                try
+                {
+                    if (!_stream.iterator.MoveNext()) continue;
+                    var message = _stream.iterator.Current;
+
+                    _dataSubscriber(new Message
+                    {
+                        Key = message.Key == null ? null : Encoding.UTF8.GetString(message.Key),
+                        Value = message.Payload == null ? null : Encoding.UTF8.GetString(message.Payload)
+                    });
+                }
+                catch (Exception ex)
+                {
+                    _errorSubscriber?.Invoke(ex);
+                }
+            }
+            _closeSubscriber?.Invoke();
+        }
+
+        public void Shutdown()
+        {
+            _running = false;
+            _tokenSource.Cancel();
+        }
+    }
+}

--- a/SimpleKafka/KafkaTopic.cs
+++ b/SimpleKafka/KafkaTopic.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using Kafka.Client.Cfg;
+using Kafka.Client.Producers;
+using Kafka.Client.Utils;
+using Kafka.Client.ZooKeeperIntegration;
+using KafkaMessage = Kafka.Client.Messages.Message;
+
+namespace SimpleKafka
+{
+    public interface IKafkaTopic : IDisposable
+    {
+        void Send(params Message[] messages);
+    }
+
+    public class KafkaTopic : IKafkaTopic
+    {
+        private readonly string _name;
+        private readonly Producer<string, KafkaMessage> _producer;
+
+        public KafkaTopic(IZooKeeperClient zkClient, string name)
+        {
+            _name = name;
+            var brokers = ZkUtils.GetAllBrokersInCluster(zkClient);
+            _producer = new Producer<string, KafkaMessage>(
+                new ProducerConfiguration(
+                    brokers
+                        .Select(b => new BrokerConfiguration
+                        {
+                            BrokerId = b.Id,
+                            Host = b.Host,
+                            Port = b.Port
+                        }).ToList()
+                    )
+                );
+        }
+
+        public void Send(params Message[] messages)
+        {
+            _producer.Send(
+                messages
+                    .Select(m => new ProducerData<string, KafkaMessage>(
+                        _name,
+                        m.Key,
+                        new KafkaMessage(Encoding.UTF8.GetBytes(m.Value)))
+                    )
+                );
+        }
+
+        public void Dispose()
+        {
+            _producer.Dispose();
+        }
+    }
+}

--- a/SimpleKafka/Message.cs
+++ b/SimpleKafka/Message.cs
@@ -1,0 +1,8 @@
+﻿namespace SimpleKafka
+{
+    public class Message
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/SimpleKafka/Properties/AssemblyInfo.cs
+++ b/SimpleKafka/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SimpleKafka")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SimpleKafka")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5b0923fc-bf89-43d8-a3d7-1dee71dbd26d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SimpleKafka/SimpleKafka.csproj
+++ b/SimpleKafka/SimpleKafka.csproj
@@ -53,6 +53,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KafkaClient.cs" />
+    <Compile Include="KafkaConsumer.cs" />
+    <Compile Include="KafkaConsumerInstance.cs" />
+    <Compile Include="KafkaConsumerStream.cs" />
     <Compile Include="KafkaTopic.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SimpleKafka/SimpleKafka.csproj
+++ b/SimpleKafka/SimpleKafka.csproj
@@ -4,17 +4,15 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{74056D3B-B715-4D64-BC36-0807F1C468E9}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <ProjectGuid>{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}</ProjectGuid>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Producer</RootNamespace>
-    <AssemblyName>Producer</AssemblyName>
+    <RootNamespace>SimpleKafka</RootNamespace>
+    <AssemblyName>SimpleKafka</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -24,7 +22,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -41,10 +38,6 @@
       <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Metrics, Version=0.2.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Metrics.NET.0.2.16\lib\net45\Metrics.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -59,18 +52,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="KafkaClient.cs" />
+    <Compile Include="KafkaTopic.cs" />
+    <Compile Include="Message.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\SimpleKafka\SimpleKafka.csproj">
-      <Project>{5B0923FC-BF89-43D8-A3D7-1DEE71DBD26D}</Project>
-      <Name>SimpleKafka</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SimpleKafka/packages.config
+++ b/SimpleKafka/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="KafkaNET.Library" version="1.0.0-CI00000" targetFramework="net452" />
+  <package id="log4net" version="1.2.10" targetFramework="net452" />
+  <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Introduce SimpleKafka library to abstract the KafkaNET library.
- Use KafkaClient to manage connection and production of abstractions
- Use KafkaTopic to publish messages
- Use KafkaConsumer, KafkaConsumerInstance, KafkaConsumerStream to abstract consumer streaming
