### PR TITLE
Fix port exhaustion

### DIFF
--- a/src/Kafka.Basic/KafkaSimpleConsumerStream.cs
+++ b/src/Kafka.Basic/KafkaSimpleConsumerStream.cs
@@ -191,7 +191,7 @@ namespace Kafka.Basic
 
                     var lastOffset = messages.Last().MessageOffset;
 
-                    if ((count + _nextOffset) != (lastOffset + 1))
+                    if (count + _nextOffset != lastOffset + 1)
                     {
                         var error = $"PullMessage offset payloadCount out-of-sync,topic={_topicName},leader={_consumer.Config.Broker},partition={_partition},payloadCount={count},FetchOffset={_nextOffset},lastOffset={lastOffset},retryCount={retryCount},maxRetry={maxRetry}";
                         GetNextOffset();

--- a/src/Kafka.Basic/KafkaSimpleConsumerStream.cs
+++ b/src/Kafka.Basic/KafkaSimpleConsumerStream.cs
@@ -79,7 +79,6 @@ namespace Kafka.Basic
                 IEnumerable<MessageAndOffset> messageAndOffsets = null;
                 try
                 {
-                    GetNextOffset();
                     messageAndOffsets = Fetch();
                 }
                 catch (Exception ex)
@@ -161,44 +160,41 @@ namespace Kafka.Basic
 
                     if (response == null)
                     {
-                        throw new KeyNotFoundException(
-                            string.Format("FetchRequest returned null response,fetchOffset={0},leader={1},topic={2},partition={3}",
-                            _nextOffset, _consumer.Config.Broker, _topicName, _partition));
+                        throw new KeyNotFoundException($"FetchRequest returned null response,fetchOffset={_nextOffset},leader={_consumer.Config.Broker},topic={_topicName},partition={_partition}");
                     }
 
                     var partitionData = response.PartitionData(_topicName, _partition);
                     if (partitionData == null)
                     {
-                        throw new KeyNotFoundException(
-                            $"PartitionData is null,fetchOffset={_nextOffset},leader={_consumer.Config.Broker},topic={_topicName},partition={_partition}"
-                            );
+                        throw new KeyNotFoundException($"PartitionData is null,fetchOffset={_nextOffset},leader={_consumer.Config.Broker},topic={_topicName},partition={_partition}");
                     }
 
                     if (partitionData.Error == ErrorMapping.OffsetOutOfRangeCode)
                     {
                         var error = $"PullMessage OffsetOutOfRangeCode,change to Latest,topic={_topicName},leader={_consumer.Config.Broker},partition={_partition},FetchOffset={_nextOffset},retryCount={retryCount},maxRetry={maxRetry}";
+                        GetNextOffset();
                         return null;
                     }
 
                     if (partitionData.Error != ErrorMapping.NoError)
                     {
-                        var error =
-                            $"PullMessage ErrorCode={partitionData.Error},topic={_topicName},leader={_consumer.Config.Broker},partition={_partition},FetchOffset={_nextOffset},retryCount={retryCount},maxRetry={maxRetry}";
+                        var error = $"PullMessage ErrorCode={partitionData.Error},topic={_topicName},leader={_consumer.Config.Broker},partition={_partition},FetchOffset={_nextOffset},retryCount={retryCount},maxRetry={maxRetry}";
+                        GetNextOffset();
                         return null;
                     }
 
                     success = true;
                     var messages = partitionData.GetMessageAndOffsets();
                     if (messages == null || !messages.Any()) return messages;
+
+                    var count = messages.Count;
+
+                    var lastOffset = messages.Last().MessageOffset;
+
+                    if ((count + _nextOffset) != (lastOffset + 1))
                     {
-                        var count = messages.Count;
-
-                        var lastOffset = messages.Last().MessageOffset;
-
-                        if ((count + _nextOffset) != (lastOffset + 1))
-                        {
-                            var error = $"PullMessage offset payloadCount out-of-sync,topic={_topicName},leader={_consumer.Config.Broker},partition={_partition},payloadCount={count},FetchOffset={_nextOffset},lastOffset={lastOffset},retryCount={retryCount},maxRetry={maxRetry}";
-                        }
+                        var error = $"PullMessage offset payloadCount out-of-sync,topic={_topicName},leader={_consumer.Config.Broker},partition={_partition},payloadCount={count},FetchOffset={_nextOffset},lastOffset={lastOffset},retryCount={retryCount},maxRetry={maxRetry}";
+                        GetNextOffset();
                     }
 
                     return messages;
@@ -209,6 +205,7 @@ namespace Kafka.Basic
                     {
                         throw;
                     }
+                    GetNextOffset();
                 }
                 finally
                 {

--- a/src/Kafka.Basic/KafkaTopic.cs
+++ b/src/Kafka.Basic/KafkaTopic.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Kafka.Client.Cfg;
 using Kafka.Client.Producers;
 using KafkaMessage = Kafka.Client.Messages.Message;
 
@@ -15,7 +14,7 @@ namespace Kafka.Basic
     {
         private readonly string _name;
         private readonly IProducer<string, KafkaMessage> _producer;
-        private IZookeeperClient _zkClient;
+        private readonly IZookeeperClient _zkClient;
 
         public KafkaTopic(IZookeeperConnection zkConnect, string name)
         {

--- a/src/Kafka.Basic/Properties/AssemblyInfo.cs
+++ b/src/Kafka.Basic/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/test/Kafka.Basic.Test/Properties/AssemblyInfo.cs
+++ b/test/Kafka.Basic.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/test/Test.Consumer/Properties/AssemblyInfo.cs
+++ b/test/Test.Consumer/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/test/Test.Consumer/SimpleConsumer.cs
+++ b/test/Test.Consumer/SimpleConsumer.cs
@@ -13,7 +13,7 @@ namespace Consumer
             var testTopic = opts.Topic;
             var partition = opts.Partition;
             var offset = opts.Offset;
-
+            
             var timer = Metric.Timer("Received", Unit.Events);
             Metric.Config.WithReporting(r => r.WithConsoleReport(TimeSpan.FromSeconds(5)));
 
@@ -24,7 +24,6 @@ namespace Consumer
                 handler.Set();
             };
 
-            Thread.Sleep(5000);
             using (var client = new KafkaClient(zookeeperString))
             using (var consumer = client.SimpleConsumer())
             using (var stream = consumer.Subscribe(testTopic, partition, offset))

--- a/test/Test.Producer/Properties/AssemblyInfo.cs
+++ b/test/Test.Producer/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
Calling GetNextOffset() at the beginning of each loop in the simple consumer was unnecessarily creating **lots** of TCP connections. We only really want this to happen if we're fetching an out of range offset or talking to a broker that is no longer the leader...
