### PR TITLE
default acks to 1

### DIFF
--- a/src/Kafka.Basic/Kafka.Basic.csproj
+++ b/src/Kafka.Basic/Kafka.Basic.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="KafkaNET.Library, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\KafkaNet.0.1.20\lib\net45\KafkaNET.Library.dll</HintPath>
+      <HintPath>..\..\packages\KafkaNet.0.1.22\lib\net45\KafkaNET.Library.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">

--- a/src/Kafka.Basic/Kafka.Basic.csproj
+++ b/src/Kafka.Basic/Kafka.Basic.csproj
@@ -70,6 +70,7 @@
     <Compile Include="KafkaTopic.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="MessageExtensions.cs" />
+    <Compile Include="ProducerConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="KafkaSimpleConsumer.cs" />
     <Compile Include="ConsumedMessage.cs" />

--- a/src/Kafka.Basic/ProducerConfig.cs
+++ b/src/Kafka.Basic/ProducerConfig.cs
@@ -1,0 +1,18 @@
+﻿namespace Kafka.Basic
+{
+    public class ProducerConfig
+    {
+        public const short DefaultAcks = 1;
+
+        public short Acks { get; set; }
+
+        public static ProducerConfig Default()
+        {
+            return new ProducerConfig
+            {
+                Acks = DefaultAcks
+            };
+        }
+
+    }
+}

--- a/src/Kafka.Basic/ZookeeperClient.cs
+++ b/src/Kafka.Basic/ZookeeperClient.cs
@@ -13,6 +13,7 @@ namespace Kafka.Basic
     {
         IEnumerable<Broker> GetAllBrokers();
         IProducer<TKey, TMessage> CreateProducer<TKey, TMessage>();
+        IProducer<TKey, TMessage> CreateProducer<TKey, TMessage>(ProducerConfig config);
     }
 
     public class ZookeeperClient : IZookeeperClient
@@ -36,7 +37,12 @@ namespace Kafka.Basic
 
         public IProducer<TKey, TMessage> CreateProducer<TKey, TMessage>()
         {
-            var config = new ProducerConfiguration(
+            return CreateProducer<TKey, TMessage>(ProducerConfig.Default());
+        }
+
+        public IProducer<TKey, TMessage> CreateProducer<TKey, TMessage>(ProducerConfig config)
+        {
+            var producerConfiguration = new ProducerConfiguration(
                 GetAllBrokers()
                     .Select(b => new BrokerConfiguration
                     {
@@ -44,9 +50,12 @@ namespace Kafka.Basic
                         Host = b.Host,
                         Port = b.Port
                     }).ToList()
-                );
+                )
+            {
+                RequiredAcks = config.Acks
+            };
 
-            return new Producer<TKey, TMessage>(config);
+            return new Producer<TKey, TMessage>(producerConfiguration);
         }
 
         public void Dispose()

--- a/src/Kafka.Basic/packages.config
+++ b/src/Kafka.Basic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="KafkaNet" version="0.1.20" targetFramework="net451" />
+  <package id="KafkaNet" version="0.1.22" targetFramework="net451" />
   <package id="log4net" version="1.2.10" targetFramework="net451" />
   <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net451" />
 </packages>

--- a/test/Kafka.Basic.Test/Kafka.Basic.Test.csproj
+++ b/test/Kafka.Basic.Test/Kafka.Basic.Test.csproj
@@ -43,7 +43,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="KafkaNET.Library, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\KafkaNet.0.1.20\lib\net45\KafkaNET.Library.dll</HintPath>
+      <HintPath>..\..\packages\KafkaNet.0.1.22\lib\net45\KafkaNET.Library.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">

--- a/test/Kafka.Basic.Test/packages.config
+++ b/test/Kafka.Basic.Test/packages.config
@@ -4,7 +4,7 @@
   <package id="AutoFixture.AutoMoq" version="3.40.1" targetFramework="net451" />
   <package id="AutoFixture.Xunit2" version="3.40.1" targetFramework="net451" />
   <package id="FluentAssertions" version="4.2.2" targetFramework="net451" />
-  <package id="KafkaNet" version="0.1.20" targetFramework="net451" />
+  <package id="KafkaNet" version="0.1.22" targetFramework="net451" />
   <package id="log4net" version="1.2.10" targetFramework="net451" />
   <package id="Moq" version="4.1.1308.2120" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />

--- a/test/Test.Producer/Program.cs
+++ b/test/Test.Producer/Program.cs
@@ -21,14 +21,11 @@ namespace Producer
 
         private static int Run(Options options)
         {
-            var zkConnect = options.ZkConnect;
-            var testTopic = options.Topic;
-
             var timer = Metric.Timer("Sent", Unit.Events);
             Metric.Config.WithReporting(r => r.WithConsoleReport(TimeSpan.FromSeconds(5)));
 
-            var client = new KafkaClient(zkConnect);
-            var topic = client.Topic(testTopic);
+            var client = new KafkaClient(options.ZkConnect);
+            var topic = client.Topic(options.Topic);
 
             var published = 0;
             var stop = false;


### PR DESCRIPTION
Avoid losing messages due to failed broker by setting RequireAcks to 1 by default
