### PR TITLE
Fixing a consumer shutdown issue

### DIFF
--- a/src/Kafka.Basic/BatchedConsumer.cs
+++ b/src/Kafka.Basic/BatchedConsumer.cs
@@ -156,6 +156,8 @@ namespace Kafka.Basic
 
                         for (var i = 0; i < messages.Length; i += _maxBatchSize)
                         {
+                            if (_consumer == null) break;
+
                             var taken = messages.Skip(i).Take(_maxBatchSize).ToArray();
                             Logger.Debug($"Skip {i}, take {_maxBatchSize}, get {taken.Length}.");
 


### PR DESCRIPTION
Fixing a problem where batched consumer attempts to process subsequent batches after shutdown is called (it can never commit them as shutdown has set consumer to null). This also leads to very long shutdown times and offsets never being updated.
